### PR TITLE
Avoid disappearing URI path segments in join

### DIFF
--- a/lib/rdf/marmotta.rb
+++ b/lib/rdf/marmotta.rb
@@ -18,7 +18,8 @@ module RDF
       @endpoints = DEFAULT_OPTIONS
       @endpoints.merge!(options)
       @endpoints.each do |k, v|
-        @endpoints[k] = ::URI.join(base_url, v)
+        next unless RDF::URI(v.to_s).relative?
+        @endpoints[k] = (RDF::URI(base_url.to_s) / v.to_s)
       end
     end
 


### PR DESCRIPTION
Some versions of ::URI.join seem to do this:

    ::URI.join('http://localhost:8080/marmotta', 'moomin')
    # => 'http://localhost:8080/moomin'

This avoids that problem by being a bit less clever about gluing together urls.